### PR TITLE
Update code of conduct

### DIFF
--- a/Code_Of_Conduct.md
+++ b/Code_Of_Conduct.md
@@ -1,68 +1,68 @@
-version: v1.1
--------------
-This code of conduct outlines our expectations for participants within the **Pitt Computer Science Club** community, as well as steps to reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored. Anyone who violates this code of conduct may be banned from the community.
+# Pitt CSC Code of Conduct
 
-Our open source community strives to:
+version: v1.2
+-------------
+This code of conduct outlines our expectations for participants within the **Pitt Computer Science Club** community as well as steps to reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored. Anyone who violates this code of conduct may be banned from the community.
+
+Our open-source community strives to:
 
 * **Be friendly and patient.**
-* **Be welcoming**: We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
-* **Be considerate**: Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
-* **Be respectful**:  Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one.
-* **Be careful in the words that we choose**: we are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable.
+* **Be welcoming**: We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to, members of any race, ethnicity, culture, national origin, color, immigration status, socioeconomic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+* **Be considerate**: Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a worldwide community, so you might not be communicating in someone else's primary language.
+* **Be respectful**:  Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It's important to remember that a community where people feel uncomfortable or threatened is not a productive one.
+* **Be careful in the words that we choose**: We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable.
 * **Try to understand why we disagree**: Disagreements, both social and technical, happen all the time. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of our community comes from its diversity, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
 
 ## Definitions
 
 Harassment includes, but is not limited to:
 
-- Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, age, regional discrimination, political or religious affiliation
+- Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neurotypicality/neurodiversity, physical appearance, body size, race, age, regional discrimination, political affliation, or religious belief
 - Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment
-- Deliberate misgendering. This includes deadnaming or persistently using a pronoun that does not correctly reflect a person's gender identity. You must address people by the name they give you when not addressing them by their username or handle
-- Physical contact and simulated physical contact (eg, textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop
+- Deliberate misgendering. This includes deadnaming (referring to a transgender individual by a name they used prior to transitioning) or persistently using a pronoun that does not correctly reflect a person's gender identity. You must address people by the name they give you when not addressing them by their username or handle.
+- Physical contact and simulated physical contact (e.g., textual descriptions like "\*hug\*" or "\*backrub\*") without consent or after a request to stop
 - Threats of violence, both physical and psychological
-- Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm
+- Incitement of violence towards any individual, including encouraging a person to commit suicide or engage in self-harm
 - Deliberate intimidation
 - Stalking or following
 - Harassing photography or recording, including logging online activity for harassment purposes
 - Sustained disruption of discussion
-- Unwelcome sexual attention, including gratuitous or off-topic sexual images or behaviour
+- Unwelcome sexual attention, including gratuitous or off-topic sexual images or behavior
 - Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
 - Continued one-on-one communication after requests to cease
-- Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect others from intentional abuse
+- Deliberate "outing" of any aspect of a person's identity without their consent except as necessary to protect others from intentional abuse
 - Publication of non-harassing private communication
 
-Our open source community prioritizes marginalized people’s safety over privileged people’s comfort. We will not act on complaints regarding:
+Our open-source community prioritizes marginalized people's safety over privileged people's comfort. We will not act on complaints regarding:
 
-- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
-- Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you”
+- 'Reverse' -isms, including 'reverse racism', 'reverse sexism', and 'cisphobia'
+- Reasonable communication of boundaries, such as "leave me alone", "go away", or "I'm not discussing this with you"
 - Refusal to explain or debate social justice concepts
-- Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
+- Criticizing racist, sexist, cisgenderist, or otherwise oppressive behavior or assumptions
 
 ## Advertisements
 
-Advertisements are **not** to be posted in the Pitt Computer Science Club Discord without prior officer approval. Advertisements may be deleted at the discretion of the Pitt Computer Science Club officers.
+Advertisements are **not** to be posted in the Pitt CSC Discord server without prior officer approval. Advertisements may be deleted at the discretion of the Pitt CSC officers.
 
 ### Diversity Statement
 
 We encourage everyone to participate and are committed to building a community for all. Although we will fail at times, we seek to treat everyone both as fairly and equally as possible. Whenever a participant has made a mistake, we expect them to take responsibility for it. If someone has been harmed or offended, it is our responsibility to listen carefully and respectfully, and do our best to right the wrong.
 
-Although this list cannot be exhaustive, we explicitly honor diversity in age, gender, gender identity or expression, culture, ethnicity, language, national origin, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, and technical ability. We will not tolerate discrimination based on any of the protected
-characteristics above, including participants with disabilities.
+Although this list cannot be exhaustive, we explicitly honor diversity in age, gender, gender identity or expression, culture, ethnicity, language, national origin, political belief, profession, race, religion, sexual orientation, socioeconomic status, and technical ability. We will not tolerate discrimination based on any of the protected characteristics above, including participants with disabilities.
 
 ### Reporting Issues
 
-If you experience or witness unacceptable behavior—or have any other concerns—please report it by contacting us via **PittCSC@gmail.com**. All reports will be handled with discretion. In your report please include:
+If you experience or witness unacceptable behavior—or have any other concerns—please report it by contacting us via **pittcsc@gmail.com**. All reports will be handled with discretion. In your report, please include:
 
-- Your contact information.
-- Names (real, nicknames, or pseudonyms) of any individuals involved. If there are additional witnesses, please
-include them as well. Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger), please include a link.
-- Any additional information that may be helpful.
+- Your contact information
+- Names (real, nicknames, or pseudonyms) of any individuals involved. If there are additional witnesses, please include them as well. Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g., a mailing list archive, public IRC logger, email conversation, or private/direct messages on social media), please include a link.
+- Any additional information that may be helpful
 
 After filing a report, a representative will contact you personally, review the incident, follow up with any additional questions, and make a decision as to how to respond. If the person who is harassing you is part of the response team, they will recuse themselves from handling your incident. If the complaint originates from a member of the response team, it will be handled by a different member of the response team. We will respect confidentiality requests for the purpose of protecting victims of abuse.
 
 ### Attribution & Acknowledgements
 
-We all stand on the shoulders of giants across many open source communities.  We'd like to thank the communities and projects that established code of conducts and diversity statements as our inspiration:
+We all stand on the shoulders of giants across many open source communities. We'd like to thank the communities and projects that established code of conducts and diversity statements as our inspiration:
 
 * [Django](https://www.djangoproject.com/conduct/reporting/)
 * [Python](https://www.python.org/community/diversity/)


### PR DESCRIPTION
- Fixed grammar, spelling, and wording (not sure why there was the occasional British spelling for some words)
- Update language regarding diversity and inclusion ("neuroatypicality" -> "neurodiversity", defining deadnaming, and "cissexist" -> "cisgenderist")